### PR TITLE
chore!: PREV-103 - Rename nodeId to fileId

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -43,13 +43,13 @@ import java.io.InputStream;
 class Test {
 
   public static void main(String[] argv) {
-    nodeId = "fe81dea6-dc90-4468-8aac-e0ec71dbb49d";
+    fileId = "fe81dea6-dc90-4468-8aac-e0ec71dbb49d";
     version = 1;
     accountId = "fe81dea6";
     type = ServiceType.FILES;
     // data initialization
     // GET
-    Query imagePreviewQuery = new Query.QueryBuilder(accountId, nodeId, version, type)
+    Query imagePreviewQuery = new Query.QueryBuilder(accountId, fileId, version, type)
       .setCrop(True)
       .setPreviewArea("300x200")
       .build();

--- a/src/main/java/com/zextras/carbonio/preview/queries/Query.java
+++ b/src/main/java/com/zextras/carbonio/preview/queries/Query.java
@@ -16,7 +16,7 @@ public class Query {
   // Required if using non ce version
   private final String fileOwnerId;
   //Required if using a get
-  private final String nodeId;
+  private final String fileId;
   private final Integer     version;
   private final ServiceType type;
   //Image required always
@@ -33,7 +33,7 @@ public class Query {
 
   private Query(QueryBuilder builder) {
     this.fileOwnerId = builder.fileOwnerId;
-    this.nodeId = builder.nodeId;
+    this.fileId = builder.fileId;
     this.version = builder.version;
     this.type = builder.type;
     this.previewArea = builder.previewArea;
@@ -49,8 +49,8 @@ public class Query {
     return Optional.ofNullable(fileOwnerId);
   }
 
-  public Optional<String> getNodeId() {
-    return Optional.ofNullable(nodeId);
+  public Optional<String> getFileId() {
+    return Optional.ofNullable(fileId);
   }
 
   public Optional<Integer> getVersion() {
@@ -112,7 +112,7 @@ public class Query {
     // Required parameters setup
 
     baseUriBuilder.append('/');
-    getNodeId().ifPresent(n -> baseUriBuilder.append(n).append('/'));
+    getFileId().ifPresent(n -> baseUriBuilder.append(n).append('/'));
     getVersion().ifPresent(v -> baseUriBuilder.append(v).append('/'));
     getPreviewArea().ifPresent(area -> baseUriBuilder.append(area).append('/'));
 
@@ -143,7 +143,7 @@ public class Query {
 
     //Required if using a get
     private String fileOwnerId;
-    private String nodeId;
+    private String fileId;
     private Integer     version;
     private ServiceType type;
     //Image required always
@@ -159,22 +159,22 @@ public class Query {
 
     public QueryBuilder(
       String fileOwnerId,
-      String nodeId,
+      String fileId,
       int version,
       ServiceType type
     ) {
       this.fileOwnerId = fileOwnerId;
-      this.nodeId = nodeId;
+      this.fileId = fileId;
       this.version = version;
       this.type = type;
     }
 
     public QueryBuilder(
-      String nodeId,
+      String fileId,
       int version,
       ServiceType type
     ) {
-      this.nodeId = nodeId;
+      this.fileId = fileId;
       this.version = version;
       this.type = type;
     }
@@ -202,8 +202,8 @@ public class Query {
       return this;
     }
 
-    public QueryBuilder setNodeId(String nodeId) {
-      this.nodeId = nodeId;
+    public QueryBuilder setFileId(String fileId) {
+      this.fileId = fileId;
       return this;
     }
 


### PR DESCRIPTION
Node id was a legacy name carried on from the files module. The preview service should always use file id as the variable name from now on.