### PR TITLE
fix: PREV-105 - Remove try-with-resources usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.zextras.carbonio.preview</groupId>
   <artifactId>carbonio-preview-sdk</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
   <name>carbonio-preview-sdk</name>
 

--- a/src/main/java/com/zextras/carbonio/preview/PreviewClient.java
+++ b/src/main/java/com/zextras/carbonio/preview/PreviewClient.java
@@ -338,8 +338,11 @@ public class PreviewClient {
 
   private Try<BlobResponse> sendRequestToPreviewService(HttpRequestBase request) {
 
-    try (CloseableHttpClient httpClient = HttpClients.createMinimal();
-      CloseableHttpResponse response = httpClient.execute(request)) {
+    try {
+      // The response is not consumed in this code block so if the http client is closed then also
+      // the communication with the service will be closed breaking the response stream of the blob
+      CloseableHttpClient httpClient = HttpClients.createMinimal();
+      CloseableHttpResponse response = httpClient.execute(request);
       int statusCode = response.getStatusLine().getStatusCode();
       switch (statusCode) {
         case HttpStatus.SC_OK:
@@ -384,6 +387,4 @@ public class PreviewClient {
       return false;
     }
   }
-
-
 }


### PR DESCRIPTION
Removed the `try-with-resources` usage in the HttpClient creation because the response is not consumed in the code block where the client is created. So if the http client is closed then also the communication with the service will be closed breaking the response stream of the blob.