### PR TITLE
feat: PREV-22 : Add GIF as output format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.zextras.carbonio.preview</groupId>
   <artifactId>carbonio-preview-sdk</artifactId>
-  <version>0.2.4</version>
+  <version>0.2.5</version>
   <packaging>jar</packaging>
   <name>carbonio-preview-sdk</name>
 

--- a/src/main/java/com/zextras/carbonio/preview/queries/enums/Format.java
+++ b/src/main/java/com/zextras/carbonio/preview/queries/enums/Format.java
@@ -6,5 +6,6 @@ package com.zextras.carbonio.preview.queries.enums;
 
 public enum Format {
   PNG,
-  JPEG
+  JPEG,
+  GIF
 }


### PR DESCRIPTION
SDK needs to add gif as supported output format, otherwise gif cannot be converted to gif but only to images

refs: PREV-22