### PR TITLE
chore: update jenkins library versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,17 +61,12 @@ pipeline {
                 }
             }
         }
-        stage('Setup') {
-            steps {
-                withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                    sh 'cp $SETTINGS_PATH settings-jenkins.xml'
-                }
-            }
-        }
         stage('Build') {
             steps {
                 container('jdk-17') {
-                    sh 'mvn -B --settings settings-jenkins.xml package'
+                    withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                        sh 'mvn -B -s $SETTINGS_PATH package'
+                    }
                 }
             }
         }
@@ -81,7 +76,9 @@ pipeline {
             }
             steps {
                 container('jdk-17') {
-                    sh 'mvn -B --settings settings-jenkins.xml verify'
+                    withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                        sh 'mvn -B -s $SETTINGS_PATH verify'
+                    }
                 }
             }
         }
@@ -91,7 +88,9 @@ pipeline {
             }
             steps {
                 container('jdk-17') {
-                    sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
+                    withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                        sh 'mvn -B -s $SETTINGS_PATH verify -P generate-jacoco-full-report'
+                    }
                     recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED')
                 }
             }
@@ -148,7 +147,9 @@ pipeline {
                         profile = '-P prod'
                     }
                     container('jdk-17') {
-                        sh "mvn -B --settings settings-jenkins.xml ${profile} deploy"
+                        withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                            sh "mvn -B -s \$SETTINGS_PATH ${profile} deploy"
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,11 @@ library(
 )
 
 library(
-    identifier: 'jenkins-packages-build-library@1.0.4',
+    identifier: 'jenkins-lib-common@1.1.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-        credentialsId: 'jenkins-integration-with-github-account'
+        credentialsId: 'jenkins-integration-with-github-account',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
     ])
 )
 
@@ -54,10 +54,12 @@ pipeline {
         )
     }
     stages {
-        stage('Checkout') {
+        stage('Setup') {
             steps {
+                checkout scm
                 script {
-                    checkoutWithMetadata()
+                    gitMetadata()
+                    properties(defaultPipelineProperties())
                 }
             }
         }


### PR DESCRIPTION
## Summary

Updates Jenkins library with improvements and version updates.

## Changes Applied

- chore(deps): update to jenkins-lib-common@1.1.2
- chore: migrate Maven settings to inline injection

## Details

### Library Migration (jenkins-lib-common@1.1.2)
- Updated library declaration from jenkins-packages-build-library@1.0.4
- Reordered credentialsId before remote in library config
- Renamed Checkout stage to Setup
- Added gitMetadata() and properties(defaultPipelineProperties()) calls

### Maven Settings Improvements
- Removed settings.xml copy step
- Injected credentials directly via -s flag
- Wrapped Maven commands with inline credential binding for security

## References

- [jenkins-lib-common CHANGELOG](https://github.com/zextras/jenkins-lib-common/blob/main/CHANGELOG.md)