### PR TITLE
ci(jenkins): switch Prepare Release agent to sm-release-v1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
         stage('Prepare Release') {
             agent {
                 node {
-                    label 'nodejs-v1'
+                    label 'sm-release-v1'
                 }
             }
             when {
@@ -118,7 +118,7 @@ pipeline {
             }
             steps {
                 script {
-                    container('nodejs-20') {
+                    container('nodejs-22') {
                         prepareRelease(
                             repoName: 'carbonio-preview-sdk'
                         )


### PR DESCRIPTION
Fix pod parking deadlock by moving Prepare Release off nodejs-v1 to sm-release-v1.